### PR TITLE
Cleanup props

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jest": "29.3.1",
     "jest-cli": "29.3.1",
     "jest-environment-jsdom": "29.3.1",
-    "msw": "^1.2.2",
+    "msw": "1.2.2",
     "npm-check-updates": "16.3.16",
     "sass": "1.56.0",
     "sass-loader": "13.1.0",

--- a/src/StateStore/store.ts
+++ b/src/StateStore/store.ts
@@ -151,13 +151,13 @@ class stateStore implements Store {
         this.currentCategoryPosts[imageData.post_index].thumbnail_image = imageData.image_url;
     };
 
-    setCurrentPost = (postData: Post) => {
+    setCurrentPost = (postData: Post, tagNames: string[] = [], imageUrl = '') => {
         const visiblePostData: VisiblePost = {
             postId: parseInt(postData.id),
             postTitle: postData.title.rendered,
             tags: postData.tags,
-            tagNames: [],
-            fullImageUrl: null,
+            tagNames,
+            fullImageUrl: imageUrl,
             width: 0,
             height: 0,
             featured_media: postData.featured_media

--- a/src/StateStore/store.ts
+++ b/src/StateStore/store.ts
@@ -153,7 +153,7 @@ class stateStore implements Store {
 
     setCurrentPost = (postData: Post, tagNames: string[] = [], imageUrl = '') => {
         const visiblePostData: VisiblePost = {
-            postId: parseInt(postData.id),
+            postId: postData.id,
             postTitle: postData.title.rendered,
             tags: postData.tags,
             tagNames,

--- a/src/assets/stylesheets/_building_blocks.scss
+++ b/src/assets/stylesheets/_building_blocks.scss
@@ -1,5 +1,8 @@
 //Set up styling for basic building-block pieces of the UI
 body {
+  --number-of-columns: 5;
+  --number-of-rows: 2;
+  --modal-transition-time: 300ms;
   margin: 0;
   overflow: hidden;
 }

--- a/src/components/Categories/Categories.tsx
+++ b/src/components/Categories/Categories.tsx
@@ -32,7 +32,7 @@ const Categories: React.FC<CategoriesProps> = ({
     const endIndex = startIndex + maxItemsPerPage;
 
     const setRows = () => {
-        const numberOfColumns = parseInt(document.body.style.getPropertyValue('--number-of-columns'));
+        const numberOfColumns = parseInt(document.body.style.getPropertyValue('--number-of-columns')) || 1;
         const numberOfCategories = maxItemsPerPage;
         document.body.style.setProperty('--number-of-rows', `${numberOfCategories / numberOfColumns}`);
     };

--- a/src/components/Categories/Categories.tsx
+++ b/src/components/Categories/Categories.tsx
@@ -9,37 +9,45 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { Store } from '../../utils/types';
+import { Category, ScreenInfo, SiteInfo } from '../../utils/types';
 import CategoryThumbnail from '../CategoryThumbnail/CategoryThumbnail';
 import PaginationNavigation from '../PaginationNavigation/PaginationNavigation';
 
 interface CategoriesProps {
-    stateStore: Store
+    maxItemsPerPage: number,
+    screenInfo: ScreenInfo,
+    categoryList: Category[],
+    siteInfo: SiteInfo
 }
 
-const Categories: React.FC<CategoriesProps> = ({ stateStore }) => {
+const Categories: React.FC<CategoriesProps> = ({
+    maxItemsPerPage,
+    screenInfo,
+    categoryList,
+    siteInfo
+}) => {
     const [currentPageIndex, setCurrentPageIndex] = useState<number>(1);
 
-    const startIndex = (currentPageIndex - 1) * stateStore.maxItemsPerPage;
-    const endIndex = startIndex + stateStore.maxItemsPerPage;
+    const startIndex = (currentPageIndex - 1) * maxItemsPerPage;
+    const endIndex = startIndex + maxItemsPerPage;
 
     const setRows = () => {
         const numberOfColumns = parseInt(document.body.style.getPropertyValue('--number-of-columns'));
-        const numberOfCategories = stateStore.maxItemsPerPage;
+        const numberOfCategories = maxItemsPerPage;
         document.body.style.setProperty('--number-of-rows', `${numberOfCategories / numberOfColumns}`);
     };
 
     useEffect(() => {
         setRows();
-    }, [stateStore.screenInfo.width, stateStore.screenInfo.height]);
+    }, [screenInfo.width, screenInfo.height]);
 
     return (
         <div className="category-list">
-            {stateStore.categoryList.slice(startIndex, endIndex)
+            {categoryList.slice(startIndex, endIndex)
                 .map(category => {
-                    return (<CategoryThumbnail key={category.id.toString()} id={category.id} name={category.name} stateStore={stateStore} />);
+                    return (<CategoryThumbnail key={category.id.toString()} id={category.id} name={category.name} siteInfo={siteInfo} />);
                 })}
-            <PaginationNavigation totalPages={stateStore.categoryList.length / stateStore.maxItemsPerPage} currentPageIndex={currentPageIndex} navigationFunction={(content: number) => { setCurrentPageIndex(content); }} />
+            <PaginationNavigation totalPages={categoryList.length / maxItemsPerPage} currentPageIndex={currentPageIndex} navigationFunction={(content: number) => { setCurrentPageIndex(content); }} />
         </div>
     );
 };

--- a/src/components/Category/Category.tsx
+++ b/src/components/Category/Category.tsx
@@ -14,7 +14,7 @@ import {
 
 import { getCategoryInfo, getPosts, getPostThumbnail } from '../../utils/Api';
 import {
-    Category,
+    Category as CategoryState,
     ImageData,
     Post as PostState,
     ScreenInfo,
@@ -28,9 +28,9 @@ interface CategoryProps {
     siteInfo: SiteInfo,
     screenInfo: ScreenInfo,
     currentCategoryPosts: PostState[],
-    currentCategoryData: Category,
+    currentCategoryData: CategoryState,
     setCategoryPosts: (a: PostState[]) => void,
-    setCategoryData: (a: Category) => void,
+    setCategoryData: (a: CategoryState) => void,
     setThumbnailImageUrl: (a: ImageData) => void
 }
 

--- a/src/components/Category/Category.tsx
+++ b/src/components/Category/Category.tsx
@@ -13,38 +13,64 @@ import {
 } from 'react-router-dom';
 
 import { getCategoryInfo, getPosts, getPostThumbnail } from '../../utils/Api';
-import { Store } from '../../utils/types';
+import {
+    Category,
+    ImageData,
+    Post as PostState,
+    ScreenInfo,
+    SiteInfo
+} from '../../utils/types';
 import Posts from '../Posts/Posts';
 import SectionHeader from '../SectionHeader/SectionHeader';
 
 interface CategoryProps {
-    stateStore: Store
+    maxItemsPerPage: number,
+    siteInfo: SiteInfo,
+    screenInfo: ScreenInfo,
+    currentCategoryPosts: PostState[],
+    currentCategoryData: Category,
+    setCategoryPosts: (a: PostState[]) => void,
+    setCategoryData: (a: Category) => void,
+    setThumbnailImageUrl: (a: ImageData) => void
 }
 
-const Category: React.FC<CategoryProps> = ({ stateStore }) => {
+const Category: React.FC<CategoryProps> = ({
+    maxItemsPerPage,
+    siteInfo,
+    screenInfo,
+    currentCategoryPosts,
+    currentCategoryData,
+    setCategoryPosts,
+    setCategoryData,
+    setThumbnailImageUrl
+}) => {
     const { categoryId } = useParams();
 
     useEffect(() => {
-        getPosts(parseInt(categoryId), stateStore.siteInfo.siteUrl)
+        getPosts(parseInt(categoryId), siteInfo.siteUrl)
             .then(posts => {
-                stateStore.setCategoryPosts(posts);
-                stateStore.currentCategoryPosts.forEach((post, index) => {
-                    getPostThumbnail(post.featured_media, stateStore.siteInfo.siteUrl)
+                setCategoryPosts(posts);
+                currentCategoryPosts.forEach((post, index) => {
+                    getPostThumbnail(post.featured_media, siteInfo.siteUrl)
                         .then(thumbUrl => {
-                            stateStore.setThumbnailImageUrl({ post_index: index, image_url: thumbUrl });
+                            setThumbnailImageUrl({ post_index: index, image_url: thumbUrl });
                         });
                 });
             });
-        getCategoryInfo(parseInt(categoryId), stateStore.siteInfo.siteUrl)
+        getCategoryInfo(parseInt(categoryId), siteInfo.siteUrl)
             .then(categoryInfo => {
-                stateStore.setCategoryData(categoryInfo);
+                setCategoryData(categoryInfo);
             });
     }, [categoryId]);
 
     return (
         <div className="category">
-            <SectionHeader title={stateStore.currentCategoryData.name} />
-            <Posts stateStore={stateStore} />
+            <SectionHeader title={currentCategoryData.name} />
+            <Posts
+                maxItemsPerPage={maxItemsPerPage}
+                screenInfo={screenInfo}
+                currentCategoryPosts={currentCategoryPosts}
+            />
             <Outlet />
         </div>
     );

--- a/src/components/CategoryThumbnail/CategoryThumbnail.tsx
+++ b/src/components/CategoryThumbnail/CategoryThumbnail.tsx
@@ -10,20 +10,20 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { getCategoryImage } from '../../utils/Api';
-import { Store } from '../../utils/types';
+import { SiteInfo } from '../../utils/types';
 import CategoryTitle from '../CategoryTitle/CategoryTitle';
 
 interface CategoryThumbnailProps {
     id: number,
     name: string,
-    stateStore: Store
+    siteInfo: SiteInfo
 }
 
-const CategoryThumbnail: React.FC<CategoryThumbnailProps> = ({ id, name, stateStore }) => {
+const CategoryThumbnail: React.FC<CategoryThumbnailProps> = ({ id, name, siteInfo }) => {
     const [thumbnailImageUrl, setThumbnailImageUrl] = useState('');
 
     if (!thumbnailImageUrl) {
-        getCategoryImage(id, stateStore.siteInfo.siteUrl)
+        getCategoryImage(id, siteInfo.siteUrl)
             .then(imageUrl => {
                 setThumbnailImageUrl(imageUrl);
             });

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -10,22 +10,32 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { getPage } from '../../utils/Api';
-import { Store } from '../../utils/types';
+import {
+    Page as PageState,
+    SiteInfo
+} from '../../utils/types';
 import PageContent from '../PageContent/PageContent';
 import SectionHeader from '../SectionHeader/SectionHeader';
 
 interface PageProps {
-    stateStore: Store
+    currentPageData: PageState,
+    siteInfo: SiteInfo,
+    setPageData: (a: PageState) => void
 }
 
-const Page: React.FC<PageProps> = ({ stateStore }) => {
+/*
+ * currentPageData
+ * siteInfo
+ * setPageData
+*/
+
+const Page: React.FC<PageProps> = ({ currentPageData, siteInfo, setPageData }) => {
     const { pageId } = useParams();
-    const { currentPageData } = stateStore;
 
     useEffect(() => {
-        getPage(parseInt(pageId), stateStore.siteInfo.siteUrl)
+        getPage(parseInt(pageId), siteInfo.siteUrl)
             .then(page => {
-                stateStore.setPageData(page);
+                setPageData(page);
             });
     }, [pageId]);
 

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -23,12 +23,6 @@ interface PageProps {
     setPageData: (a: PageState) => void
 }
 
-/*
- * currentPageData
- * siteInfo
- * setPageData
-*/
-
 const Page: React.FC<PageProps> = ({ currentPageData, siteInfo, setPageData }) => {
     const { pageId } = useParams();
 

--- a/src/components/PhotoPortfolio/PhotoPortfolio.tsx
+++ b/src/components/PhotoPortfolio/PhotoPortfolio.tsx
@@ -82,19 +82,54 @@ const PhotoPortfolio: React.FC<PhotoPortfolioProps> = ({ stateStore }) => {
                 <Routes>
                     <Route
                         path="/"
-                        element={<Categories stateStore={stateStore} />}
+                        element={(
+                            <Categories
+                                maxItemsPerPage={stateStore.maxItemsPerPage}
+                                screenInfo={stateStore.screenInfo}
+                                categoryList={stateStore.categoryList}
+                                siteInfo={stateStore.siteInfo}
+                            />
+                        )}
                     />
                     <Route
                         path="page/:pageId"
-                        element={<Page key={pageId} stateStore={stateStore} />}
+                        element={(
+                            <Page
+                                key={pageId}
+                                currentPageData={stateStore.currentPageData}
+                                siteInfo={stateStore.siteInfo}
+                                setPageData={stateStore.setPageData}
+                            />
+                        )}
                     />
                     <Route
                         path="category/:categoryId"
-                        element={<Category key={categoryId} stateStore={stateStore} />}
+                        element={(
+                            <Category
+                                key={categoryId}
+                                maxItemsPerPage={stateStore.maxItemsPerPage}
+                                siteInfo={stateStore.siteInfo}
+                                screenInfo={stateStore.screenInfo}
+                                currentCategoryPosts={stateStore.currentCategoryPosts}
+                                currentCategoryData={stateStore.currentCategoryData}
+                                setCategoryPosts={stateStore.setCategoryPosts}
+                                setCategoryData={stateStore.setCategoryData}
+                                setThumbnailImageUrl={stateStore.setThumbnailImageUrl}
+                            />
+                        )}
                     >
                         <Route
                             path="post/:postId"
-                            element={<Post stateStore={stateStore} />}
+                            element={(
+                                <Post
+                                    screenInfo={stateStore.screenInfo}
+                                    siteInfo={stateStore.siteInfo}
+                                    visiblePost={stateStore.visiblePost}
+                                    currentCategoryPosts={stateStore.currentCategoryPosts}
+                                    clearVisiblePostTagNames={stateStore.clearVisiblePostTagNames}
+                                    setCurrentPost={stateStore.setCurrentPost}
+                                />
+                            )}
                         />
                     </Route>
                 </Routes>

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -114,8 +114,8 @@ const Post: React.FC<PostProps> = ({
                 <PostImage
                     imageUrl={visiblePost.fullImageUrl}
                     postHeight={visiblePost.height}
-                    previousPost={getPreviousPost(postId, currentCategoryPosts)}
-                    nextPost={getNextPost(postId, currentCategoryPosts)}
+                    previousPost={getPreviousPost(parseInt(postId), currentCategoryPosts)}
+                    nextPost={getNextPost(parseInt(postId), currentCategoryPosts)}
                 />
                 <PostFooter tagNames={visiblePost.tagNames} />
             </div>

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -89,7 +89,7 @@ const Post: React.FC<PostProps> = ({
     }, [postId]);
 
     useEffect(() => {
-        if (visiblePost.fullImageUrl !== null && visiblePost.fullImageUrl !== undefined) {
+        if (visiblePost.fullImageUrl) {
             image.src = visiblePost.fullImageUrl;
         }
 

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -48,6 +48,9 @@ const Post: React.FC<PostProps> = ({
     const { categoryId, postId } = useParams();
     const navigate = useNavigate();
     let element: HTMLElement = null;
+    // Create ref here and pass to PostImage
+    // Create state for imageHeight
+    // In image.onload(), update imageHeight with ref.current.clientHeight
 
     const closeModalHandler = () => {
         navigate(`/category/${categoryId}`);
@@ -113,7 +116,6 @@ const Post: React.FC<PostProps> = ({
                 <PostTitlebar postTitle={visiblePost.postTitle} />
                 <PostImage
                     imageUrl={visiblePost.fullImageUrl}
-                    postHeight={visiblePost.height}
                     previousPost={getPreviousPost(parseInt(postId), currentCategoryPosts)}
                     nextPost={getNextPost(parseInt(postId), currentCategoryPosts)}
                 />

--- a/src/components/PostFooter/PostFooter.tsx
+++ b/src/components/PostFooter/PostFooter.tsx
@@ -7,16 +7,14 @@ import './PostFooter.css';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { Store } from '../../utils/types';
-
 interface PostFooterProps {
-    stateStore: Store
+    tagNames: string[]
 }
 
-const PostFooter: React.FC<PostFooterProps> = ({ stateStore }) => {
+const PostFooter: React.FC<PostFooterProps> = ({ tagNames }) => {
     return (
         <div className="post-footer">
-            <div className="labels">{stateStore.visiblePost.tagNames.join(', ')}</div>
+            <div className="labels">{tagNames.join(', ')}</div>
         </div>
     );
 };

--- a/src/components/PostImage/PostImage.tsx
+++ b/src/components/PostImage/PostImage.tsx
@@ -6,31 +6,25 @@ import './PostImage.css';
 
 import { observer } from 'mobx-react';
 import * as React from 'react';
-import { useCallback, useRef, useState } from 'react';
+import { forwardRef, useState } from 'react';
 
 import PostNavigationArrow from '../PostNavigationArrow/PostNavigationArrow';
 
 interface PostImageProps {
     imageUrl: string,
+    imageHeight: number,
     previousPost: number,
-    nextPost: number
+    nextPost: number,
+    ref: React.ForwardedRef<HTMLImageElement>
 }
 
-const PostImage: React.FC<PostImageProps> = ({
+const PostImage: React.FC<PostImageProps> = forwardRef(({
     imageUrl,
+    imageHeight,
     previousPost,
     nextPost
-}) => {
+}, ref) => {
     const [arrowsVisible, setArrowsVisible] = useState<boolean>(false);
-    const [imageHeight, setImageHeight] = useState<number>(0);
-    const imageRef = useRef(null);
-
-    const updateImageHeight = useCallback((element: HTMLElement) => {
-        imageRef.current = element;
-        if (element) {
-            setImageHeight(element.getBoundingClientRect().height);
-        }
-    }, []);
 
     const onMouseOverHandler = () => {
         setArrowsVisible(true);
@@ -43,11 +37,11 @@ const PostImage: React.FC<PostImageProps> = ({
     return (
         <div className="post-image" onMouseOver={onMouseOverHandler.bind(this)} onMouseOut={onMouseOutHandler.bind(this)}>
             {arrowsVisible && <PostNavigationArrow imageHeight={imageHeight} direction="previous" postId={previousPost} />}
-            <img ref={updateImageHeight} src={imageUrl} />
+            <img ref={ref} src={imageUrl} />
             {arrowsVisible && <PostNavigationArrow imageHeight={imageHeight} direction="next" postId={nextPost} />}
         </div>
     );
-};
+});
 
 PostImage.displayName = 'PostImage';
 

--- a/src/components/PostImage/PostImage.tsx
+++ b/src/components/PostImage/PostImage.tsx
@@ -13,8 +13,8 @@ import PostNavigationArrow from '../PostNavigationArrow/PostNavigationArrow';
 interface PostImageProps {
     imageUrl: string,
     postHeight: number,
-    previousPost: string,
-    nextPost: string
+    previousPost: number,
+    nextPost: number
 }
 
 const PostImage: React.FC<PostImageProps> = ({

--- a/src/components/PostImage/PostImage.tsx
+++ b/src/components/PostImage/PostImage.tsx
@@ -6,24 +6,31 @@ import './PostImage.css';
 
 import { observer } from 'mobx-react';
 import * as React from 'react';
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import PostNavigationArrow from '../PostNavigationArrow/PostNavigationArrow';
 
 interface PostImageProps {
     imageUrl: string,
-    postHeight: number,
     previousPost: number,
     nextPost: number
 }
 
 const PostImage: React.FC<PostImageProps> = ({
     imageUrl,
-    postHeight,
     previousPost,
     nextPost
 }) => {
     const [arrowsVisible, setArrowsVisible] = useState<boolean>(false);
+    const [imageHeight, setImageHeight] = useState<number>(0);
+    const imageRef = useRef(null);
+
+    const updateImageHeight = useCallback((element: HTMLElement) => {
+        imageRef.current = element;
+        if (element) {
+            setImageHeight(element.getBoundingClientRect().height);
+        }
+    }, []);
 
     const onMouseOverHandler = () => {
         setArrowsVisible(true);
@@ -35,9 +42,9 @@ const PostImage: React.FC<PostImageProps> = ({
 
     return (
         <div className="post-image" onMouseOver={onMouseOverHandler.bind(this)} onMouseOut={onMouseOutHandler.bind(this)}>
-            {arrowsVisible && <PostNavigationArrow postHeight={postHeight} direction="previous" postId={previousPost} />}
-            <img src={imageUrl} />
-            {arrowsVisible && <PostNavigationArrow postHeight={postHeight} direction="next" postId={nextPost} />}
+            {arrowsVisible && <PostNavigationArrow imageHeight={imageHeight} direction="previous" postId={previousPost} />}
+            <img ref={updateImageHeight} src={imageUrl} />
+            {arrowsVisible && <PostNavigationArrow imageHeight={imageHeight} direction="next" postId={nextPost} />}
         </div>
     );
 };

--- a/src/components/PostImage/PostImage.tsx
+++ b/src/components/PostImage/PostImage.tsx
@@ -8,16 +8,21 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import { useState } from 'react';
 
-import { Store } from '../../utils/types';
 import PostNavigationArrow from '../PostNavigationArrow/PostNavigationArrow';
 
 interface PostImageProps {
-    stateStore: Store,
+    imageUrl: string,
+    postHeight: number,
     previousPost: string,
     nextPost: string
 }
 
-const PostImage: React.FC<PostImageProps> = ({ stateStore, previousPost, nextPost }) => {
+const PostImage: React.FC<PostImageProps> = ({
+    imageUrl,
+    postHeight,
+    previousPost,
+    nextPost
+}) => {
     const [arrowsVisible, setArrowsVisible] = useState<boolean>(false);
 
     const onMouseOverHandler = () => {
@@ -30,9 +35,9 @@ const PostImage: React.FC<PostImageProps> = ({ stateStore, previousPost, nextPos
 
     return (
         <div className="post-image" onMouseOver={onMouseOverHandler.bind(this)} onMouseOut={onMouseOutHandler.bind(this)}>
-            {arrowsVisible && <PostNavigationArrow stateStore={stateStore} direction="previous" postId={previousPost} />}
-            <img src={stateStore.visiblePost.fullImageUrl} />
-            {arrowsVisible && <PostNavigationArrow stateStore={stateStore} direction="next" postId={nextPost} />}
+            {arrowsVisible && <PostNavigationArrow postHeight={postHeight} direction="previous" postId={previousPost} />}
+            <img src={imageUrl} />
+            {arrowsVisible && <PostNavigationArrow postHeight={postHeight} direction="next" postId={nextPost} />}
         </div>
     );
 };

--- a/src/components/PostNavigationArrow/PostNavigationArrow.tsx
+++ b/src/components/PostNavigationArrow/PostNavigationArrow.tsx
@@ -9,17 +9,17 @@ import * as React from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 interface PostNavigationArrowProps {
-    postHeight: number,
+    imageHeight: number,
     direction: string,
     postId: number
 }
 
-const PostNavigationArrow: React.FC<PostNavigationArrowProps> = ({ postHeight = 0, direction, postId }) => {
+const PostNavigationArrow: React.FC<PostNavigationArrowProps> = ({ imageHeight = 0, direction, postId }) => {
     const { categoryId } = useParams();
 
     // TODO: calculate these based on a variable somewhere - they are navigationArrowHeight - (postHeaderHight + postFooterHeight)
     // What we want here is actually the height of just the image and not the whole modal
-    const top = (postHeight / 2) - 41 - (48 + 32);
+    const top = (imageHeight / 2) - 41;
     const divStyle = direction === 'previous' ? { top: `${top}px`, left: '0px' } : { top: `${top}px`, right: '0px' };
     const classNames = ['post-navigation-arrow', postId ? 'active' : 'disabled', direction];
 

--- a/src/components/PostNavigationArrow/PostNavigationArrow.tsx
+++ b/src/components/PostNavigationArrow/PostNavigationArrow.tsx
@@ -11,7 +11,7 @@ import { Link, useParams } from 'react-router-dom';
 interface PostNavigationArrowProps {
     postHeight: number,
     direction: string,
-    postId: string
+    postId: number
 }
 
 const PostNavigationArrow: React.FC<PostNavigationArrowProps> = ({ postHeight = 0, direction, postId }) => {

--- a/src/components/PostNavigationArrow/PostNavigationArrow.tsx
+++ b/src/components/PostNavigationArrow/PostNavigationArrow.tsx
@@ -17,8 +17,9 @@ interface PostNavigationArrowProps {
 const PostNavigationArrow: React.FC<PostNavigationArrowProps> = ({ postHeight = 0, direction, postId }) => {
     const { categoryId } = useParams();
 
-    // TODO: calc this based on a height variable, not just a hard-coded 41
-    const top = (postHeight / 2) - 41;
+    // TODO: calculate these based on a variable somewhere - they are navigationArrowHeight - (postHeaderHight + postFooterHeight)
+    // What we want here is actually the height of just the image and not the whole modal
+    const top = (postHeight / 2) - 41 - (48 + 32);
     const divStyle = direction === 'previous' ? { top: `${top}px`, left: '0px' } : { top: `${top}px`, right: '0px' };
     const classNames = ['post-navigation-arrow', postId ? 'active' : 'disabled', direction];
 

--- a/src/components/PostNavigationArrow/PostNavigationArrow.tsx
+++ b/src/components/PostNavigationArrow/PostNavigationArrow.tsx
@@ -8,19 +8,17 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import { Link, useParams } from 'react-router-dom';
 
-import { Store } from '../../utils/types';
-
 interface PostNavigationArrowProps {
-    stateStore: Store,
+    postHeight: number,
     direction: string,
     postId: string
 }
 
-const PostNavigationArrow: React.FC<PostNavigationArrowProps> = ({ stateStore, direction, postId }) => {
+const PostNavigationArrow: React.FC<PostNavigationArrowProps> = ({ postHeight = 0, direction, postId }) => {
     const { categoryId } = useParams();
 
     // TODO: calc this based on a height variable, not just a hard-coded 41
-    const top = stateStore.visiblePost.height ? (stateStore.visiblePost.height / 2) - (41) : 0;
+    const top = (postHeight / 2) - 41;
     const divStyle = direction === 'previous' ? { top: `${top}px`, left: '0px' } : { top: `${top}px`, right: '0px' };
     const classNames = ['post-navigation-arrow', postId ? 'active' : 'disabled', direction];
 

--- a/src/components/PostThumbnail/PostThumbnail.tsx
+++ b/src/components/PostThumbnail/PostThumbnail.tsx
@@ -8,16 +8,17 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
-import { Store } from '../../utils/types';
-
 interface PostThumbnailProps {
-    stateStore: Store,
     id: string,
-    index: number
+    thumbnailImage: string
 }
 
-const PostThumbnail: React.FC<PostThumbnailProps> = ({ stateStore, id, index }) => {
-    const divStyle = { backgroundImage: `url(${stateStore.currentCategoryPosts[index].thumbnail_image ? stateStore.currentCategoryPosts[index].thumbnail_image : ''})` };
+/*
+ * currentCategoryPosts
+*/
+
+const PostThumbnail: React.FC<PostThumbnailProps> = ({ id, thumbnailImage = '' }) => {
+    const divStyle = { backgroundImage: `url(${thumbnailImage})` };
     const location = useLocation();
 
     return (

--- a/src/components/PostThumbnail/PostThumbnail.tsx
+++ b/src/components/PostThumbnail/PostThumbnail.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 interface PostThumbnailProps {
-    id: string,
+    id: number,
     thumbnailImage: string
 }
 

--- a/src/components/Posts/Posts.tsx
+++ b/src/components/Posts/Posts.tsx
@@ -8,37 +8,39 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { Store } from '../../utils/types';
+import { Post as PostState, ScreenInfo } from '../../utils/types';
 import PaginationNavigation from '../PaginationNavigation/PaginationNavigation';
 import PostThumbnail from '../PostThumbnail/PostThumbnail';
 
 interface PostsProps {
-    stateStore: Store
+    maxItemsPerPage: number,
+    screenInfo: ScreenInfo,
+    currentCategoryPosts: PostState[]
 }
 
-const Posts: React.FC<PostsProps> = ({ stateStore }) => {
+const Posts: React.FC<PostsProps> = ({ maxItemsPerPage, screenInfo, currentCategoryPosts }) => {
     const [currentPageIndex, setCurrentPageIndex] = useState(1);
 
-    const startIndex = (currentPageIndex - 1) * stateStore.maxItemsPerPage;
-    const endIndex = startIndex + stateStore.maxItemsPerPage;
+    const startIndex = (currentPageIndex - 1) * maxItemsPerPage;
+    const endIndex = startIndex + maxItemsPerPage;
 
     const setRows = () => {
         const numberOfColumns = parseInt(document.body.style.getPropertyValue('--number-of-columns'));
-        const numberOfPosts = stateStore.maxItemsPerPage;
+        const numberOfPosts = maxItemsPerPage;
         document.body.style.setProperty('--number-of-rows', `${numberOfPosts / numberOfColumns}`);
     };
 
     useEffect(() => {
         setRows();
-    }, [stateStore.screenInfo.width, stateStore.screenInfo.height]);
+    }, [screenInfo.width, screenInfo.height]);
 
     return (
         <div className="posts">
-            {stateStore.currentCategoryPosts.slice(startIndex, endIndex)
+            {currentCategoryPosts.slice(startIndex, endIndex)
                 .map((post, index) => {
-                    return (<PostThumbnail key={post.id.toString()} stateStore={stateStore} id={post.id} index={index + startIndex} />);
+                    return (<PostThumbnail key={post.id.toString()} id={post.id} thumbnailImage={currentCategoryPosts[index].thumbnail_image} />);
                 })}
-            <PaginationNavigation totalPages={stateStore.currentCategoryPosts.length / stateStore.maxItemsPerPage} currentPageIndex={currentPageIndex} navigationFunction={content => { setCurrentPageIndex(content); }} />
+            <PaginationNavigation totalPages={currentCategoryPosts.length / maxItemsPerPage} currentPageIndex={currentPageIndex} navigationFunction={content => { setCurrentPageIndex(content); }} />
         </div>
     );
 };

--- a/src/components/Posts/Posts.tsx
+++ b/src/components/Posts/Posts.tsx
@@ -25,7 +25,7 @@ const Posts: React.FC<PostsProps> = ({ maxItemsPerPage, screenInfo, currentCateg
     const endIndex = startIndex + maxItemsPerPage;
 
     const setRows = () => {
-        const numberOfColumns = parseInt(document.body.style.getPropertyValue('--number-of-columns'));
+        const numberOfColumns = parseInt(document.body.style.getPropertyValue('--number-of-columns')) || 1;
         const numberOfPosts = maxItemsPerPage;
         document.body.style.setProperty('--number-of-rows', `${numberOfPosts / numberOfColumns}`);
     };

--- a/src/components/__tests__/__snapshots__/category.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/category.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`Category displays 1`] = `
     >
       <div
         class="post-thumbnail"
-        style="background-image: url(https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg);"
+        style="background-image: url();"
       />
     </a>
     <a
@@ -29,7 +29,7 @@ exports[`Category displays 1`] = `
     >
       <div
         class="post-thumbnail"
-        style="background-image: url(https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg);"
+        style="background-image: url();"
       />
     </a>
     <div

--- a/src/components/__tests__/__snapshots__/category.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/category.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`Category displays 1`] = `
     >
       <div
         class="post-thumbnail"
-        style="background-image: url();"
+        style="background-image: url(https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg);"
       />
     </a>
     <a
@@ -29,7 +29,7 @@ exports[`Category displays 1`] = `
     >
       <div
         class="post-thumbnail"
-        style="background-image: url();"
+        style="background-image: url(https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg);"
       />
     </a>
     <div

--- a/src/components/__tests__/__snapshots__/post.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/post.test.jsx.snap
@@ -3,9 +3,11 @@
 exports[`Post displays 1`] = `
 <div
   class="post-background"
+  style="width: 500px; height: 500px;"
 >
   <div
     class="post"
+    style="top: 50px;"
   >
     <div
       class="post-titlebar"
@@ -39,6 +41,7 @@ exports[`Post displays 1`] = `
     >
       <img
         src="http://foo"
+        style="height: 400px;"
       />
     </div>
     <div
@@ -47,7 +50,7 @@ exports[`Post displays 1`] = `
       <div
         class="labels"
       >
-        foo, bob
+        moe, curly
       </div>
     </div>
   </div>

--- a/src/components/__tests__/__snapshots__/postfooter.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/postfooter.test.jsx.snap
@@ -6,6 +6,8 @@ exports[`PostFooter displays 1`] = `
 >
   <div
     class="labels"
-  />
+  >
+    something, somethingelse
+  </div>
 </div>
 `;

--- a/src/components/__tests__/__snapshots__/postnavigationarrow.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/postnavigationarrow.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`PostNavigationArrow displays 1`] = `
 <div
   class="post-navigation-arrow active previous"
-  style="top: 0px; left: 0px;"
+  style="top: 209px; left: 0px;"
 >
   <a
     href="/category/undefined/post/35"

--- a/src/components/__tests__/__snapshots__/posts.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/posts.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`Posts displays 1`] = `
   >
     <div
       class="post-thumbnail"
-      style="background-image: url();"
+      style="background-image: url(https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg);"
     />
   </a>
   <a
@@ -17,7 +17,7 @@ exports[`Posts displays 1`] = `
   >
     <div
       class="post-thumbnail"
-      style="background-image: url();"
+      style="background-image: url(https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg);"
     />
   </a>
   <div

--- a/src/components/__tests__/categories.test.jsx
+++ b/src/components/__tests__/categories.test.jsx
@@ -6,6 +6,16 @@ import { MemoryRouter } from 'react-router-dom';
 import StateStore from '../../StateStore/store';
 import Categories from '../Categories/Categories';
 
+const screenInfo = {
+    width: 500,
+    height: 500
+};
+
+const siteInfo = {
+    siteName: 'Through a Pinhole',
+    siteUrl: 'throughapinhole.com'
+};
+
 const categories = [
     {
         id: 23,
@@ -42,7 +52,12 @@ test('Category list displays', async () => {
     await act(async () => {
         container = render(
             <MemoryRouter>
-                <Categories stateStore={store} />
+                <Categories
+                    maxItemsPerPage={10}
+                    screenInfo={screenInfo}
+                    categoryList={categories}
+                    siteInfo={siteInfo}
+                />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/category.test.jsx
+++ b/src/components/__tests__/category.test.jsx
@@ -3,19 +3,30 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import StateStore from '../../StateStore/store';
 import Category from '../Category/Category';
+
+const screenInfo = {
+    width: 500,
+    height: 500
+};
+
+const siteInfo = {
+    siteName: 'Through a Pinhole',
+    siteUrl: 'throughapinhole.com'
+};
 
 const posts = [
     {
         id: 887,
         featured_media: 142,
-        categories: [220]
+        categories: [220],
+        thumnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
     },
     {
         id: 824,
         featured_media: 820,
-        categories: [220]
+        categories: [220],
+        thumnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
     }
 ];
 
@@ -39,12 +50,20 @@ jest.mock('../../utils/Api', () => ({
 }));
 
 test('Category displays', async () => {
-    const store = new StateStore();
     let container;
     await act(async () => {
         container = render(
             <MemoryRouter initialEntries={['/category/35']}>
-                <Category stateStore={store} />
+                <Category
+                    maxItemsPerPage={2}
+                    siteInfo={screenInfo}
+                    screenInfo={siteInfo}
+                    currentCategoryPosts={posts}
+                    currentCategoryData={category}
+                    setCategoryPosts={() => {}}
+                    setCategoryData={() => {}}
+                    setThumbnailImageUrl={() => {}}
+                />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/category.test.jsx
+++ b/src/components/__tests__/category.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
@@ -20,13 +20,13 @@ const posts = [
         id: 887,
         featured_media: 142,
         categories: [220],
-        thumnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
+        thumbnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
     },
     {
         id: 824,
         featured_media: 820,
         categories: [220],
-        thumnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
+        thumbnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
     }
 ];
 
@@ -49,6 +49,10 @@ jest.mock('../../utils/Api', () => ({
     getCategoryImage: () => Promise.resolve('https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg')
 }));
 
+const setCategoryPostsMock = jest.fn();
+const setCategoryDataMock = jest.fn();
+const setThumbnailImageUrlMock = jest.fn();
+
 test('Category displays', async () => {
     let container;
     await act(async () => {
@@ -56,16 +60,21 @@ test('Category displays', async () => {
             <MemoryRouter initialEntries={['/category/35']}>
                 <Category
                     maxItemsPerPage={2}
-                    siteInfo={screenInfo}
-                    screenInfo={siteInfo}
+                    siteInfo={siteInfo}
+                    screenInfo={screenInfo}
                     currentCategoryPosts={posts}
                     currentCategoryData={category}
-                    setCategoryPosts={() => {}}
-                    setCategoryData={() => {}}
-                    setThumbnailImageUrl={() => {}}
+                    setCategoryPosts={setCategoryPostsMock}
+                    setCategoryData={setCategoryDataMock}
+                    setThumbnailImageUrl={setThumbnailImageUrlMock}
                 />
             </MemoryRouter>
         ).container;
+    });
+    await waitFor(() => {
+        expect(setCategoryPostsMock).toHaveBeenCalledTimes(1);
+        expect(setCategoryDataMock).toHaveBeenCalledTimes(1);
+        expect(setThumbnailImageUrlMock).toHaveBeenCalledTimes(2);
     });
     expect(container.firstChild).toMatchSnapshot();
 });

--- a/src/components/__tests__/categorythumbnail.test.jsx
+++ b/src/components/__tests__/categorythumbnail.test.jsx
@@ -8,6 +8,10 @@ import CategoryThumbnail from '../CategoryThumbnail/CategoryThumbnail';
 
 const id = 5;
 const name = 'Test Category';
+const siteInfo = {
+    siteName: 'Through a Pinhole',
+    siteUrl: 'throughapinhole.com'
+};
 
 jest.mock('../../utils/Api', () => ({
     getCategoryImage: () => Promise.resolve('https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg')
@@ -19,7 +23,7 @@ test('CategoryThumbnail displays', async () => {
     await act(async () => {
         container = render(
             <MemoryRouter>
-                <CategoryThumbnail id={id} name={name} stateStore={store} />
+                <CategoryThumbnail id={id} name={name} siteInfo={siteInfo} />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/categorythumbnail.test.jsx
+++ b/src/components/__tests__/categorythumbnail.test.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import StateStore from '../../StateStore/store';
 import CategoryThumbnail from '../CategoryThumbnail/CategoryThumbnail';
 
 const id = 5;
@@ -18,7 +17,6 @@ jest.mock('../../utils/Api', () => ({
 }));
 
 test('CategoryThumbnail displays', async () => {
-    const store = new StateStore();
     let container;
     await act(async () => {
         container = render(

--- a/src/components/__tests__/page.test.jsx
+++ b/src/components/__tests__/page.test.jsx
@@ -6,6 +6,11 @@ import { MemoryRouter } from 'react-router-dom';
 import StateStore from '../../StateStore/store';
 import Page from '../Page/Page';
 
+const siteInfo = {
+    siteName: 'Through a Pinhole',
+    siteUrl: 'throughapinhole.com'
+};
+
 const page = {
     id: 150,
     content: {
@@ -26,7 +31,11 @@ test('Page displays', async () => {
     await act(async () => {
         container = render(
             <MemoryRouter initialEntries={['/page/150']}>
-                <Page stateStore={store} />
+                <Page
+                    currentPageData={page}
+                    siteInfo={siteInfo}
+                    setPageData={store.setPageData}
+                />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/post.test.jsx
+++ b/src/components/__tests__/post.test.jsx
@@ -3,8 +3,17 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import StateStore from '../../StateStore/store';
 import Post from '../Post/Post';
+
+const screenInfo = {
+    width: 500,
+    height: 500
+};
+
+const siteInfo = {
+    siteName: 'Through a Pinhole',
+    siteUrl: 'throughapinhole.com'
+};
 
 const pages = [
     {
@@ -43,6 +52,17 @@ const categories = [
     }
 ];
 
+const visiblePost = {
+    postId: 150,
+    postTitle: 'foo',
+    tags: [0, 1],
+    tagNames: ['moe', 'curly'],
+    fullImageUrl: 'http://foo',
+    width: 500,
+    height: 500,
+    featured_media: 0
+};
+
 const posts = [
     {
         id: 150,
@@ -79,12 +99,18 @@ jest.mock('../../utils/Api', () => ({
 }));
 
 test('Post displays', async () => {
-    const store = new StateStore();
     let container;
     await act(async () => {
         container = render(
             <MemoryRouter initialEntries={['/page/150']}>
-                <Post stateStore={store} />
+                <Post
+                    screenInfo={screenInfo}
+                    siteInfo={siteInfo}
+                    visiblePost={visiblePost}
+                    currentCategoryPosts={posts}
+                    clearVisiblePostTagNames={() => {}}
+                    setCurrentPost={() => {}}
+                />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/postfooter.test.jsx
+++ b/src/components/__tests__/postfooter.test.jsx
@@ -3,16 +3,15 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import StateStore from '../../StateStore/store';
 import PostFooter from '../PostFooter/PostFooter';
 
 test('PostFooter displays', async () => {
-    const store = new StateStore();
+    const tagNames = ['something', 'somethingelse'];
     let container;
     await act(async () => {
         container = render(
             <MemoryRouter>
-                <PostFooter stateStore={store} />
+                <PostFooter tagNames={tagNames} />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/postnavigationarrow.test.jsx
+++ b/src/components/__tests__/postnavigationarrow.test.jsx
@@ -3,19 +3,18 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import StateStore from '../../StateStore/store';
 import PostNavigationArrow from '../PostNavigationArrow/PostNavigationArrow';
 
+const imageHeight = 500;
 const direction = 'previous';
 const postId = 35;
 
 test('PostNavigationArrow displays', async () => {
-    const store = new StateStore();
     let container;
     await act(async () => {
         container = render(
             <MemoryRouter>
-                <PostNavigationArrow stateStore={store} direction={direction} postId={postId} />
+                <PostNavigationArrow imageHeight={imageHeight} direction={direction} postId={postId} />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/posts.test.jsx
+++ b/src/components/__tests__/posts.test.jsx
@@ -3,8 +3,12 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import StateStore from '../../StateStore/store';
 import Posts from '../Posts/Posts';
+
+const screenInfo = {
+    width: 500,
+    height: 500
+};
 
 const posts = [
     {
@@ -26,13 +30,15 @@ const posts = [
 ];
 
 test('Posts displays', async () => {
-    const store = new StateStore();
-    store.setCategoryPosts(posts);
     let container;
     await act(async () => {
         container = render(
             <MemoryRouter>
-                <Posts stateStore={store} />
+                <Posts
+                    maxItemsPerPage={10}
+                    screenInfo={screenInfo}
+                    currentCategoryPosts={posts}
+                />
             </MemoryRouter>
         ).container;
     });

--- a/src/components/__tests__/posts.test.jsx
+++ b/src/components/__tests__/posts.test.jsx
@@ -13,11 +13,20 @@ const screenInfo = {
 const posts = [
     {
         id: 887,
+        link: '',
+        modified: '',
+        slug: '',
+        type: '',
         featured_media: 142,
         categories: [220],
         title: {
             rendered: 'Some post'
-        }
+        },
+        content: {
+            rendered: 'Some content',
+            protected: false
+        },
+        thumbnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
     },
     {
         id: 889,
@@ -25,7 +34,8 @@ const posts = [
         categories: [220],
         title: {
             rendered: 'Some other post'
-        }
+        },
+        thumbnail_image: 'https://throughapinhole.com/wp-content/uploads/2018/07/DSC_1508.jpg'
     }
 ];
 

--- a/src/components/__tests__/postthumbnail.test.jsx
+++ b/src/components/__tests__/postthumbnail.test.jsx
@@ -3,25 +3,17 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import StateStore from '../../StateStore/store';
 import PostThumbnail from '../PostThumbnail/PostThumbnail';
 
-const categoryPosts = [
-    {
-        thumbnail_image: 'some_url'
-    }
-];
-
+const thumbnailImage = 'some_url';
 const postId = 35;
 
 test('PostThumbnail displays', async () => {
-    const store = new StateStore();
-    store.setCategoryPosts(categoryPosts);
     let container;
     await act(async () => {
         container = render(
             <MemoryRouter>
-                <PostThumbnail stateStore={store} id={postId} index={0} />
+                <PostThumbnail id={postId} thumbnailImage={thumbnailImage} />
             </MemoryRouter>
         ).container;
     });

--- a/src/utils/PostHelper.ts
+++ b/src/utils/PostHelper.ts
@@ -3,7 +3,8 @@ import { runInAction } from 'mobx';
 import { getPost } from './Api';
 import {
     Post,
-    Store
+    Store,
+    VisiblePost
 } from './types';
 
 export const getPostInfo = (postId: string, stateStore: Store) => {
@@ -13,6 +14,7 @@ export const getPostInfo = (postId: string, stateStore: Store) => {
     });
 };
 
+// TODO: See why these two methods are not always working OK
 export const getNextPost = (postId: string, currentCategoryPosts: Post[]) => {
     const currentIndex = currentCategoryPosts.findIndex(post => post.id === postId);
     const nextIndex = currentIndex + 1;
@@ -34,7 +36,7 @@ export const getPreviousPost = (postId: string, currentCategoryPosts: Post[]) =>
     return previousId;
 };
 
-const getPostSize = (screenWidth: number, screenHeight: number, imageWidth: number, imageHeight: number, stateStore: Store) => {
+const getPostSize = (screenWidth: number, screenHeight: number, imageWidth: number, imageHeight: number) => {
     const postTitlebar = document.querySelector('.post-titlebar');
     const postFooter = document.querySelector('.post-footer');
     const screenAspectRatio = screenWidth / screenHeight;
@@ -58,11 +60,6 @@ const getPostSize = (screenWidth: number, screenHeight: number, imageWidth: numb
     rect.image_height = height;
     rect.height = height + postTitlebar.clientHeight + postFooter.clientHeight;
 
-    runInAction(() => {
-        stateStore.visiblePost.width = width;
-        stateStore.visiblePost.height = height;
-    });
-
     return rect;
 };
 
@@ -77,11 +74,15 @@ const getPostPosition = (screenWidth: number, screenHeight: number, postWidth: n
     return position;
 };
 
-export const setPostRect = (image: HTMLImageElement, screenWidth: number, screenHeight: number, stateStore: Store) => {
+export const setPostRect = (image: HTMLImageElement, screenWidth: number, screenHeight: number, visiblePost: VisiblePost) => {
     const postElement = document.querySelector('.post') as HTMLElement;
     const imageElement = document.querySelector('.post-image > img') as HTMLElement;
     const backgroundElement = document.querySelector('.post-background') as HTMLElement;
-    const rect = getPostSize(screenWidth, screenHeight, image.width, image.height, stateStore);
+    const rect = getPostSize(screenWidth, screenHeight, image.width, image.height);
+    runInAction(() => {
+        visiblePost.width = rect.width;
+        visiblePost.height = rect.height;
+    });
     imageElement.style.width = `${rect.width}px`;
     imageElement.style.height = `${rect.image_height}px`;
     postElement.style.width = `${rect.width}px`;

--- a/src/utils/PostHelper.ts
+++ b/src/utils/PostHelper.ts
@@ -15,7 +15,7 @@ export const getPostInfo = (postId: string, stateStore: Store) => {
 };
 
 // TODO: See why these two methods are not always working OK
-export const getNextPost = (postId: string, currentCategoryPosts: Post[]) => {
+export const getNextPost = (postId: number, currentCategoryPosts: Post[]) => {
     const currentIndex = currentCategoryPosts.findIndex(post => post.id === postId);
     const nextIndex = currentIndex + 1;
     const numberOfPosts = currentCategoryPosts.length;
@@ -26,7 +26,7 @@ export const getNextPost = (postId: string, currentCategoryPosts: Post[]) => {
     return nextId;
 };
 
-export const getPreviousPost = (postId: string, currentCategoryPosts: Post[]) => {
+export const getPreviousPost = (postId: number, currentCategoryPosts: Post[]) => {
     const currentIndex = currentCategoryPosts.findIndex(post => post.id === postId);
     const previousIndex = currentIndex - 1;
     if (previousIndex < 0) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -35,7 +35,7 @@ export interface VisiblePost {
 }
 
 export interface Post {
-    id: string,
+    id: number,
     link: string,
     modified: string,
     slug: string,


### PR DESCRIPTION
Previously I was passing the state store all around, but this makes for components which are tightly coupled, so I wanted to only pass the props that were relevant for what the components render. This allows them to be more abstract and also it is more easily visible what properties they are actually using.